### PR TITLE
Fix for https://github.com/awslabs/aws-sdk-java-resources/issues/14

### DIFF
--- a/aws-resources-iam/src/test/java/com/amazonaws/resources/identitymanagement/IamIntegrationTest.java
+++ b/aws-resources-iam/src/test/java/com/amazonaws/resources/identitymanagement/IamIntegrationTest.java
@@ -14,11 +14,14 @@
  */
 package com.amazonaws.resources.identitymanagement;
 
+import java.util.UUID;
+
 import org.junit.AfterClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import com.amazonaws.resources.ServiceBuilder;
+import com.amazonaws.services.identitymanagement.model.CreateUserRequest;
 import com.amazonaws.services.identitymanagement.model.StatusType;
 
 public class IamIntegrationTest {
@@ -48,6 +51,14 @@ public class IamIntegrationTest {
             AccessKey key = user.createAccessKey();
             System.out.println("  Created: " + key.getId());
         }
+    }
+
+    @Test
+    @Ignore
+    public void testCreate() {
+        String name = UUID.randomUUID().toString();
+        User user = iam.createUser(new CreateUserRequest(name));
+        user.delete();
     }
 
     @AfterClass


### PR DESCRIPTION
The way we currently handle single-valued request identifiers assumes there's at least one response identifier to tell us how many copies to make. For cases like IAM's CreateUser (where the only identifier is the name of the user mapped in from the request), this assumption is invalid.

This change moves handling of single-valued request identifiers up alongside parent identifiers, which are handled correctly.
